### PR TITLE
Fixed compiler warnings

### DIFF
--- a/include/ImNodeFlow.h
+++ b/include/ImNodeFlow.h
@@ -204,7 +204,7 @@ namespace ImFlow
          * @param right Pointer to the input Pin of the Link
          * @param inf Pointer to the Handler that contains the Link
          */
-        explicit Link(Pin* left, Pin* right, ImNodeFlow* inf) :m_left(left), m_right(right), m_inf(inf) {}
+        explicit Link(Pin* left, Pin* right, ImNodeFlow* inf) : m_inf(inf), m_left(left), m_right(right) {}
 
         /**
          * @brief <BR>Destruction of a link
@@ -521,6 +521,7 @@ namespace ImFlow
     class BaseNode
     {
     public:
+		virtual ~BaseNode() = default;
         BaseNode() = default;
 
         /**
@@ -904,11 +905,13 @@ namespace ImFlow
          * @param style Style of the pin
          */
         explicit Pin(PinUID uid, std::string name, ConnectionFilter filter, PinType kind, BaseNode* parent, ImNodeFlow** inf, std::shared_ptr<PinStyle> style)
-            :m_uid(uid), m_name(std::move(name)), m_filter(filter), m_type(kind), m_parent(parent), m_inf(inf), m_style(std::move(style))
+            :m_uid(uid), m_name(std::move(name)), m_type(kind), m_filter(filter), m_style(std::move(style)), m_parent(parent), m_inf(inf)
             {
                 if(!m_style)
                     m_style = PinStyle::cyan();
             }
+
+        virtual ~Pin() = default;
 
         /**
          * @brief <BR>Main loop of the pin

--- a/include/ImNodeFlow.h
+++ b/include/ImNodeFlow.h
@@ -1064,7 +1064,7 @@ namespace ImFlow
          * @param inf Pointer to the Grid Handler the pin is in (same as parent)
          * @param style Style of the pin
          */
-        explicit InPin(PinUID uid, const std::string& name, ConnectionFilter filter, BaseNode* parent, T defReturn, ImNodeFlow** inf, std::shared_ptr<PinStyle> style)
+        explicit InPin(PinUID uid, const std::string& name, T defReturn, ConnectionFilter filter, BaseNode* parent, ImNodeFlow** inf, std::shared_ptr<PinStyle> style)
             : Pin(uid, name, filter, PinType_Input, parent, inf, style), m_emptyVal(defReturn) {}
 
         /**

--- a/include/ImNodeFlow.h
+++ b/include/ImNodeFlow.h
@@ -204,7 +204,7 @@ namespace ImFlow
          * @param right Pointer to the input Pin of the Link
          * @param inf Pointer to the Handler that contains the Link
          */
-        explicit Link(Pin* left, Pin* right, ImNodeFlow* inf) : m_inf(inf), m_left(left), m_right(right) {}
+        explicit Link(Pin* left, Pin* right, ImNodeFlow* inf) : m_left(left), m_right(right), m_inf(inf) {} {}
 
         /**
          * @brief <BR>Destruction of a link
@@ -242,9 +242,9 @@ namespace ImFlow
          */
         [[nodiscard]] bool isSelected() const { return m_selected; }
     private:
-        ImNodeFlow* m_inf;
         Pin* m_left;
         Pin* m_right;
+        ImNodeFlow* m_inf;
         bool m_hovered = false;
         bool m_selected = false;
     };
@@ -905,7 +905,7 @@ namespace ImFlow
          * @param style Style of the pin
          */
         explicit Pin(PinUID uid, std::string name, ConnectionFilter filter, PinType kind, BaseNode* parent, ImNodeFlow** inf, std::shared_ptr<PinStyle> style)
-            :m_uid(uid), m_name(std::move(name)), m_type(kind), m_filter(filter), m_style(std::move(style)), m_parent(parent), m_inf(inf)
+            :m_uid(uid), m_name(std::move(name)), m_filter(filter), m_type(kind), m_parent(parent), m_inf(inf), m_style(std::move(style))
             {
                 if(!m_style)
                     m_style = PinStyle::cyan();
@@ -1039,11 +1039,11 @@ namespace ImFlow
         std::string m_name;
         ImVec2 m_pos = ImVec2(0.f, 0.f);
         ImVec2 m_size = ImVec2(0.f, 0.f);
-        PinType m_type;
         ConnectionFilter m_filter;
-        std::shared_ptr<PinStyle> m_style;
+        PinType m_type;
         BaseNode* m_parent = nullptr;
         ImNodeFlow** m_inf;
+        std::shared_ptr<PinStyle> m_style;
         std::function<void(Pin* p)> m_renderer;
     };
 

--- a/include/ImNodeFlow.h
+++ b/include/ImNodeFlow.h
@@ -521,7 +521,7 @@ namespace ImFlow
     class BaseNode
     {
     public:
-		virtual ~BaseNode() = default;
+        virtual ~BaseNode() = default;
         BaseNode() = default;
 
         /**

--- a/src/ImNodeFlow.cpp
+++ b/src/ImNodeFlow.cpp
@@ -60,7 +60,7 @@ namespace ImFlow {
 
         // Header
         ImGui::BeginGroup();
-        ImGui::TextColored(m_style->header_title_color, m_title.c_str());
+        ImGui::TextColored(m_style->header_title_color, "%s", m_title.c_str());
         ImGui::Spacing();
         ImGui::EndGroup();
         float headerH = ImGui::GetItemRectSize().y;

--- a/src/ImNodeFlow.inl
+++ b/src/ImNodeFlow.inl
@@ -275,7 +275,7 @@ namespace ImFlow
         }
 
         ImGui::SetCursorPos(m_pos);
-        ImGui::Text(m_name.c_str());
+        ImGui::Text("%s", m_name.c_str());
         m_size = ImGui::GetItemRectSize();
 
         drawDecoration();


### PR DESCRIPTION
This is my first pull request on github. 

I was receiving some warnings for missing virtual destructors in the BaseNode. I added virtual destructors and fixed some other warnings.

 - missing virtual destructors 
 - using non-const strings in ImGui::Text fmt 
 - initialization order in constructor initializer list different from member declaration