### PR TITLE
Fixes for dear imgui 1.92

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -87,6 +87,9 @@ int main(int, char**)
     ImGui_ImplOpenGL3_Init(glsl_version);
     ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
 
+    // Create a node editor with width and height
+    NodeEditor* neditor = new(NodeEditor)(500, 500);
+
     // Main loop
     bool done = false;
 #ifdef __EMSCRIPTEN__
@@ -121,8 +124,8 @@ int main(int, char**)
         ImGui::SetNextWindowSize(window_size);
         ImGui::SetNextWindowPos(window_pos);
         ImGui::Begin("Node Editor", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse);
-        neditor.set_size(node_editor_size);
-        neditor.draw();
+        neditor->set_size(node_editor_size);
+        neditor->draw();
         ImGui::End();
 
         // Rendering
@@ -136,6 +139,9 @@ int main(int, char**)
 #ifdef __EMSCRIPTEN__
     EMSCRIPTEN_MAINLOOP_END;
 #endif
+
+    delete neditor;
+    neditor = nullptr;
 
     // Cleanup
     ImGui_ImplOpenGL3_Shutdown();

--- a/example/example.hpp
+++ b/example/example.hpp
@@ -63,5 +63,3 @@ struct NodeEditor : ImFlow::BaseNode {
     }
 };
 
-/* Create a node editor with width and height */
-NodeEditor neditor(500, 1500);

--- a/src/context_wrapper.h
+++ b/src/context_wrapper.h
@@ -79,6 +79,7 @@ public:
     [[nodiscard]] bool hovered() const { return m_hovered; }
     [[nodiscard]] const ImVec2& scroll() const { return m_scroll; }
     ImGuiContext* getRawContext() { return m_ctx; }
+    void setFontDensity();
 private:
     ContainedContextConfig m_config;
 
@@ -101,11 +102,20 @@ inline ContainedContext::~ContainedContext()
     if (m_ctx) ImGui::DestroyContext(m_ctx);
 }
 
+// Call after Begin()
+inline void ContainedContext::setFontDensity()
+{
+#if IMGUI_VERSION_NUM >= 19198
+    ImGui::SetFontRasterizerDensity(roundf(m_scale * 100.0f) / 100.0f); // Round density to two digits.
+#endif
+}
+
 inline void ContainedContext::begin()
 {
     ImGui::PushID(this);
     ImGui::PushStyleColor(ImGuiCol_ChildBg, m_config.color);
     ImGui::BeginChild("view_port", m_config.size, 0, ImGuiWindowFlags_NoMove);
+    setFontDensity();
     ImGui::PopStyleColor();
     m_pos = ImGui::GetWindowPos();
 
@@ -140,6 +150,7 @@ inline void ContainedContext::begin()
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
     ImGui::Begin("viewport_container", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoMove
                                                 | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+    setFontDensity();
     ImGui::PopStyleVar();
 }
 

--- a/src/context_wrapper.h
+++ b/src/context_wrapper.h
@@ -122,6 +122,15 @@ inline void ContainedContext::begin()
 
     ImGui::GetIO().DisplaySize = m_size / m_scale;
     ImGui::GetIO().ConfigInputTrickleEventQueue = false;
+
+    // Copy the ImGuiBackendFlags_RendererHasTextures flag as they need to be matching.
+    // This will also copy the ImGuiBackendFlags_RendererHasVtxOffset flag which will be more optimal in case large draw calls are being made.
+    ImGui::GetIO().ConfigFlags = m_original_ctx->IO.ConfigFlags;
+    ImGui::GetIO().BackendFlags = m_original_ctx->IO.BackendFlags;
+#ifdef IMGUI_HAS_VIEWPORT
+    ImGui::GetIO().ConfigFlags &= ~(ImGuiConfigFlags_ViewportsEnable | ImGuiConfigFlags_DockingEnable);
+#endif
+
     ImGui::NewFrame();
 
     if (!m_config.extra_window_wrapper)


### PR DESCRIPTION
- Example app destroyed secondary context after first one, yet it referred to first's one atlas. It luckily worked before but won't now.
- Fixed secondary context using mismatching BackendFlags. Namely `ImGuiBackendFlags_RendererHasTextures` needs to have matching value between contexts.

With those fixes the example works again, but note that the dynamic font sizing capabilities of 1.92 are not being used yet. 
I will work on suggesting what to do to make that work, considering that you are scaling vertices manually.

Ref: https://github.com/ocornut/imgui/issues/8680