### PR TITLE
Box selection, Groups, Horizontal flip mode, Waypoints on links and multi links in sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(ImNodeFlow CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include_directories(
+    include
+)
+
+set(SOURCE_FILES
+    src/ImNodeFlow.cpp
+)
+
+add_library(ImNodeFlow SHARED ${SOURCE_FILES})
+target_compile_definitions(ImNodeFlow PRIVATE IMGUI_DEFINE_MATH_OPERATORS)
+
+target_include_directories(ImNodeFlow
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS ImNodeFlow
+    EXPORT ImNodeFlowTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(DIRECTORY include/ DESTINATION include)
+
+install(EXPORT ImNodeFlowTargets
+    FILE ImNodeFlowConfig.cmake
+    NAMESPACE ImNodeFlow::
+    DESTINATION lib/cmake/ImNodeFlow
+)

--- a/include/ImNodeFlow.h
+++ b/include/ImNodeFlow.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cmath>
 #include <memory>
+#include <cstdint>
 #include <algorithm>
 #include <functional>
 #include <unordered_map>
@@ -530,6 +531,12 @@ namespace ImFlow
         Pin* m_dragOut = nullptr;
 
         InfStyler m_style;
+
+        // Box selection
+        bool m_boxSelecting = false;
+        ImVec2 m_boxSelectStart = ImVec2(0, 0);
+        ImU32 m_boxSelectColor = IM_COL32(100, 150, 255, 50);
+        ImU32 m_boxSelectBorderColor = IM_COL32(100, 150, 255, 200);
     };
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/include/ImNodeFlow.h
+++ b/include/ImNodeFlow.h
@@ -1055,6 +1055,20 @@ namespace ImFlow
          * @param pos Position in screen coordinates
          */
         void setPos(ImVec2 pos) { m_pos = pos; }
+
+         /**
+          * @brief <BR>Get socket hit bounds for interaction
+          * @param expand_radius Optional radius to expand the socket hitbox (default uses socket_hovered_radius)
+          * @return Rectangle bounds for socket interaction
+          */
+        std::pair<ImVec2, ImVec2> getSocketHitBounds(float expand_radius = -1.0f);
+        
+        /**
+         * @brief <BR>Enable/disable automatic socket hitbox extension
+         * @param enabled If true, socket area will be included in pin hitbox
+         */
+        void setSocketHitboxEnabled(bool enabled) { m_socketHitboxEnabled = enabled; }
+
     protected:
         PinUID m_uid;
         std::string m_name;
@@ -1065,6 +1079,7 @@ namespace ImFlow
         ImNodeFlow** m_inf;
         std::shared_ptr<PinStyle> m_style;
         std::function<void(Pin* p)> m_renderer;
+        bool m_socketHitboxEnabled = true;
     };
 
     /**

--- a/src/ImNodeFlow.inl
+++ b/src/ImNodeFlow.inl
@@ -230,34 +230,56 @@ namespace ImFlow
     // -----------------------------------------------------------------------------------------------------------------
     // PIN
 
+    inline std::pair<ImVec2, ImVec2> Pin::getSocketHitBounds(float expand_radius)
+    {
+        if (expand_radius < 0.0f)
+            expand_radius = m_style->socket_hovered_radius;
+        
+        ImVec2 center = pinPoint();
+        ImVec2 tl = center - ImVec2(expand_radius, expand_radius);
+        ImVec2 br = center + ImVec2(expand_radius, expand_radius);
+        
+        return {tl, br};
+    }
+
     inline void Pin::drawSocket()
     {
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
-        ImVec2 tl = pinPoint() - ImVec2(m_style->socket_radius, m_style->socket_radius);
-        ImVec2 br = pinPoint() + ImVec2(m_style->socket_radius, m_style->socket_radius);
+        auto [tl, br] = getSocketHitBounds();
+        
+        // Déterminer si on est en hover (vérifié maintenant dans update())
+        bool socketHovered = ImGui::IsMouseHoveringRect(tl, br);
 
         if (isConnected())
             draw_list->AddCircleFilled(pinPoint(), m_style->socket_connected_radius, m_style->color, m_style->socket_shape);
         else
         {
-            if (ImGui::IsItemHovered() || ImGui::IsMouseHoveringRect(tl, br))
+            if (socketHovered)
                 draw_list->AddCircle(pinPoint(), m_style->socket_hovered_radius, m_style->color, m_style->socket_shape, m_style->socket_thickness);
             else
                 draw_list->AddCircle(pinPoint(), m_style->socket_radius, m_style->color, m_style->socket_shape, m_style->socket_thickness);
         }
-
-        if (ImGui::IsMouseHoveringRect(tl, br))
-            (*m_inf)->hovering(this);
     }
 
     inline void Pin::drawDecoration()
     {
         ImDrawList* draw_list = ImGui::GetWindowDrawList();
 
-        if (ImGui::IsItemHovered())
+        // Vérifier hover sur le texte OU le socket
+        bool itemHovered = ImGui::IsItemHovered();
+        bool socketHovered = false;
+        
+        if (m_socketHitboxEnabled)
+        {
+            auto [socket_tl, socket_br] = getSocketHitBounds();
+            socketHovered = ImGui::IsMouseHoveringRect(socket_tl, socket_br);
+        }
+
+        if (itemHovered || socketHovered)
             draw_list->AddRectFilled(m_pos - m_style->extra.padding, m_pos + m_size + m_style->extra.padding, m_style->extra.bg_hover_color, m_style->extra.bg_radius);
         else
             draw_list->AddRectFilled(m_pos - m_style->extra.padding, m_pos + m_size + m_style->extra.padding, m_style->extra.bg_color, m_style->extra.bg_radius);
+        
         draw_list->AddRect(m_pos - m_style->extra.padding, m_pos + m_size + m_style->extra.padding, m_style->extra.border_color, m_style->extra.bg_radius, 0, m_style->extra.border_thickness);
     }
 
@@ -267,17 +289,27 @@ namespace ImFlow
         if (m_renderer)
         {
             ImGui::BeginGroup();
-            ImGui::SetCursorPos(m_pos);
-            ImGui::Text("%s", m_name.c_str());
-            m_size = ImGui::GetItemRectSize();
             m_renderer(this);
             ImGui::EndGroup();
-      
-            if (ImGui::IsItemHovered())
+            m_size = ImGui::GetItemRectSize();
+            
+            // Calculer la hitbox combinée si activée
+            bool itemHovered = ImGui::IsItemHovered();
+            bool socketHovered = false;
+            
+            if (m_socketHitboxEnabled)
+            {
+                auto [socket_tl, socket_br] = getSocketHitBounds();
+                socketHovered = ImGui::IsMouseHoveringRect(socket_tl, socket_br);
+            }
+            
+            if (itemHovered || socketHovered)
                 (*m_inf)->hovering(this);
+            
             return;
         }
 
+        // Rendu standard
         ImGui::SetCursorPos(m_pos);
         ImGui::Text("%s", m_name.c_str());
         m_size = ImGui::GetItemRectSize();
@@ -285,7 +317,17 @@ namespace ImFlow
         drawDecoration();
         drawSocket();
 
-        if (ImGui::IsItemHovered())
+        // Vérifier le hover sur texte + socket
+        bool itemHovered = ImGui::IsItemHovered();
+        bool socketHovered = false;
+        
+        if (m_socketHitboxEnabled)
+        {
+            auto [socket_tl, socket_br] = getSocketHitBounds();
+            socketHovered = ImGui::IsMouseHoveringRect(socket_tl, socket_br);
+        }
+        
+        if (itemHovered || socketHovered)
             (*m_inf)->hovering(this);
     }
 

--- a/src/ImNodeFlow.inl
+++ b/src/ImNodeFlow.inl
@@ -267,9 +267,12 @@ namespace ImFlow
         if (m_renderer)
         {
             ImGui::BeginGroup();
+            ImGui::SetCursorPos(m_pos);
+            ImGui::Text("%s", m_name.c_str());
+            m_size = ImGui::GetItemRectSize();
             m_renderer(this);
             ImGui::EndGroup();
-            m_size = ImGui::GetItemRectSize();
+      
             if (ImGui::IsItemHovered())
                 (*m_inf)->hovering(this);
             return;


### PR DESCRIPTION
Hi,

This is a simple feature to add box selection for multiple nodes selection.

EDIT : WORK IN PROGRESS I will summit more patches

Fixed: group selection/deselection and group delete (without delete nodes inside). In the following capture there are these new features:

- Group
- Waypoints
- Multi links in sockets
- Horizontal flip mode

<img width="825" height="623" alt="Copie d&#39;écran_20260205_220227" src="https://github.com/user-attachments/assets/baf7091c-e3a5-4fdd-81aa-6974f8eb1503" />
