### PR TITLE
Fix duplicated ImVec2 multiplication operator

### DIFF
--- a/src/imgui_extra_math.inl
+++ b/src/imgui_extra_math.inl
@@ -31,10 +31,12 @@ inline bool operator!=(const ImVec2& lhs, const ImVec2& rhs)
 }
 # endif
 
+# if IMGUI_VERSION_NUM < 19207
 inline ImVec2 operator*(const float lhs, const ImVec2& rhs)
 {
     return ImVec2(lhs * rhs.x, lhs * rhs.y);
 }
+# endif
 
 # if IMGUI_VERSION_NUM < 18955
 inline ImVec2 operator-(const ImVec2& lhs)

--- a/src/imgui_extra_math.inl
+++ b/src/imgui_extra_math.inl
@@ -31,7 +31,7 @@ inline bool operator!=(const ImVec2& lhs, const ImVec2& rhs)
 }
 # endif
 
-# if IMGUI_VERSION_NUM < 19207
+# if IMGUI_VERSION_NUM < 19268
 inline ImVec2 operator*(const float lhs, const ImVec2& rhs)
 {
     return ImVec2(lhs * rhs.x, lhs * rhs.y);


### PR DESCRIPTION
ImGui 1.92.7 [adds new ImVec2 operators](https://github.com/ocornut/imgui/commit/3c78afbbbb03bebd4161316d4d4767362af098f0), including multiplication, which makes its implementation in imgui_extra_math.inl redundant.