### PR TITLE
PR - removing reliance on RTTI

### DIFF
--- a/include/ImNodeFlow.h
+++ b/include/ImNodeFlow.h
@@ -1,5 +1,6 @@
 #ifndef IM_NODE_FLOW
 #define IM_NODE_FLOW
+#include <type_traits>
 #pragma once
 
 #include <iostream>
@@ -1088,9 +1089,9 @@ namespace ImFlow
     class ConnectionFilter
     {
     public:
-        static std::function<bool(Pin*, Pin*)> None() { return [](Pin* out, Pin* in){ return true; }; }
-        static std::function<bool(Pin*, Pin*)> SameType() { return [](Pin* out, Pin* in) { return out->getDataType() == in->getDataType(); }; }
-        static std::function<bool(Pin*, Pin*)> Numbers() { return [](Pin* out, Pin* in){ return out->getDataType() == typeid(double) || out->getDataType() == typeid(float) || out->getDataType() == typeid(int); }; }
+        static auto None() { return [](auto*, auto*){ return true; }; }
+        static auto SameType() { return [](auto* out, auto* in) { return std::is_same_v<decltype(out->val()),decltype(in->val())>; }; }
+        static auto Numbers() { return [](auto* out, auto*){ return std::is_arithmetic_v<decltype(out->val())>; }; }
     };
 
     /**
@@ -1152,7 +1153,7 @@ namespace ImFlow
          * @brief <BR>Get pin's data type (aka: \<T>)
          * @return String containing unique information identifying the data type
          */
-        [[nodiscard]] const std::type_info& getDataType() const override { return typeid(T); };
+        // [[nodiscard]] const std::type_info& getDataType() const override { return typeid(T); };
 
         /**
          * @brief <BR>Get pin's link attachment point (socket)
@@ -1245,7 +1246,7 @@ namespace ImFlow
          * @brief <BR>Get pin's data type (aka: \<T>)
          * @return String containing unique information identifying the data type
          */
-        [[nodiscard]] const std::type_info& getDataType() const override { return typeid(T); };
+        // [[nodiscard]] const std::type_info& getDataType() const override { return typeid(T); };
     private:
         std::vector<std::weak_ptr<Link>> m_links;
         std::function<T()> m_behaviour;


### PR DESCRIPTION
Hello,

I'm working on a project where RTTI is not available and hit a stopper in ImNodeFlow in that regard.

In environments where RTTI is disabled (e.g. -fno-rtti / /GR-), typeid() is unavailable, making ConnectionFilter and getDataType() unusable.

This patch replaces the typeid-based type comparison with template-based equivalents using <type_traits>, which work without RTTI:

SameType() now uses std::is_same_v on the deduced types of connected pins
Numbers() now uses std::is_arithmetic_v on the output pin's value type
None() simplified to generic lambdas — no type info needed
getDataType() overrides commented out as the filters above no longer depend on them and they have no no-RTTI equivalent;
No behavioral change in RTTI-enabled builds for the None and Numbers filters.
SameType now performs a stricter compile-time check rather than a runtime type_info comparison.

Regards,

Lorenzo

PS: I've simply commented out getDataType() so far, let me know if you want it removed.